### PR TITLE
Update error-dialog.component.html DOM text reinterpreted as HTML

### DIFF
--- a/app/asset_browser/frontend/src/app/error-dialog/error-dialog.component.html
+++ b/app/asset_browser/frontend/src/app/error-dialog/error-dialog.component.html
@@ -1,5 +1,5 @@
 <h2 mat-dialog-title>Error</h2>
-<p class="error-message"[innerHtml] = "data.errorMessage | styleErrorMsg"></p>
+<p class="error-message" [innerText]="data.errorMessage | styleErrorMsg"></p>
 <app-progress-btn
   btnLabel='Retry'
   [btnUpdateMsg]="updateMessage"


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.